### PR TITLE
Add support for hidepid= in /proc filesystem

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,3 +42,26 @@ console_fsckfix: 'yes'
 # List of locales to enable on the host
 console_locales: [ 'en_US.UTF-8' ]
 
+
+# ---- /proc & hidepid= options ----
+
+# Mounting /proc with hidepid= allows you to hide process information of other
+# users on unprivileged accounts. This functionality is only enabled on recent
+# Linux kernels, and only on hardware hosts or KVM virtual machines. For LXC
+# containers, look in 'debops.lxc' role. For OpenVZ containers, AFAIK there's
+# no way to enable it.
+
+# Enable or disable hidepid= option in /proc. Disabling only stops Ansible
+# from adding hidepid= automatically, you need to remove the /proc entry from
+# /etc/fstab manually (and optionally remount command from /etc/rc.local)
+# because if Ansible tries to do this using 'mount' module, it will try to
+# remove /proc mount point as well. :-(
+console_proc_hidepid: True
+
+# What level of hidepid= to use (choices: 0, 1, 2)
+console_proc_hidepid_level: '2'
+
+# System group to set for /proc so that selected users can access it without
+# restrictions; this is meant for monitoring services, etc.
+console_proc_hidepid_group: 'procadmins'
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,3 +68,15 @@
     state: 'present'
   with_items: console_locales
   when: (console_locales is defined and console_locales)
+
+  # Enable hidepid= only on specific hosts
+- include: proc_hidepid.yml
+  when: ((ansible_virtualization_type is defined and
+          ansible_virtualization_role is defined and
+         (ansible_virtualization_type in ['kvm','VMware','virtualbox'] and
+          ansible_virtualization_role in ['host','guest']) or
+         (ansible_virtualization_type in ['NA'] and
+          ansible_virtualization_role in ['NA'])) or
+         (ansible_virtualization_type is undefined and
+          ansible_virtualization_role is undefined))
+

--- a/tasks/proc_hidepid.yml
+++ b/tasks/proc_hidepid.yml
@@ -1,0 +1,29 @@
+---
+
+- name: Make sure that system group with access to /proc exists
+  group:
+    name: '{{ console_proc_hidepid_group }}'
+    system: True
+    state: 'present'
+  when: console_proc_hidepid is defined and console_proc_hidepid
+
+- name: Configure /proc with hidepid= in /etc/fstab
+  mount:
+    name: '/proc'
+    src: 'proc'
+    fstype: 'proc'
+    opts: 'defaults,hidepid={{ console_proc_hidepid_level }},gid={{ console_proc_hidepid_group }}'
+    state: 'mounted'
+  when: console_proc_hidepid is defined and console_proc_hidepid
+
+  # This is a workaround for Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/mountall/+bug/1039887
+- name: Remount /proc from rc.local when needed
+  lineinfile:
+    dest: '/etc/rc.local'
+    regexp: '^mount -o remount,hidepid={{ console_proc_hidepid_level }},gid={{ console_proc_hidepid_group }} /proc'
+    line: 'mount -o remount,hidepid={{ console_proc_hidepid_level }},gid={{ console_proc_hidepid_group }} /proc'
+    insertbefore: 'exit 0'
+    state: 'present'
+  when: ((console_proc_hidepid is defined and console_proc_hidepid) and
+         (ansible_distribution in [ 'Ubuntu' ] and ansible_distribution_release in [ 'trusty' ]))
+


### PR DESCRIPTION
hidepid= option hides processes of other users from unprivileged user
accounts. This feature is enabled only on selected hosts - hardware
servers and fully virtualized VMs. Containers need to be configured
separately.
