### PR TITLE
Enforce root account and set random password

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,3 +65,18 @@ console_proc_hidepid_level: '2'
 # restrictions; this is meant for monitoring services, etc.
 console_proc_hidepid_group: 'procadmins'
 
+
+# ---- root account ----
+
+# Manage root account
+console_root: True
+
+# Password set on root account, saved in secrets
+console_root_password: '{{ lookup("password", secret + "/credentials/" + ansible_fqdn + "/console/root/password encrypt=sha512_crypt length=" + console_root_password_length) }}'
+
+# Length of the root password
+console_root_password_length: '32'
+
+# Default root shell, set to False to not change the shell
+console_root_shell: False
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,8 @@
 ---
 
-dependencies: []
+dependencies:
+
+  - role: debops.secret
 
 galaxy_info:
   author: 'Maciej Delmanowski'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,3 +82,6 @@
          (ansible_virtualization_type is undefined and
           ansible_virtualization_role is undefined))
 
+- include: root_account.yml
+  when: console_root is defined and console_root
+

--- a/tasks/root_account.yml
+++ b/tasks/root_account.yml
@@ -1,0 +1,37 @@
+---
+
+- name: Enforce root group
+  group:
+    name: 'root'
+    gid: '0'
+    system: True
+    state: 'present'
+
+- name: Enforce root user account
+  user:
+    name: 'root'
+    state: 'present'
+    group: 'root'
+    home: '/root'
+    uid: '0'
+    groups: ''
+    append: False
+    system: True
+    password: '{{ console_root_password }}'
+    update_password: 'always'
+
+- name: Enforce root shell
+  user:
+    name: 'root'
+    createhome: False
+    shell: '{{ console_root_shell }}'
+  when: console_root_shell is defined and console_root_shell
+
+- name: Enforce root home permissions
+  file:
+    path: '/root'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0700'
+


### PR DESCRIPTION
'debops.console' role will now enforce root account (UID, GID, group
membership, home directory) and set a random 32 character password.

Password is stored in 'secret/' directory, see 'debops.secret' role for
more details.