### PR TITLE
Fix empty hidepid_group interpreted as matches all groups

### DIFF
--- a/templates/etc/ansible/facts.d/proc.fact.j2
+++ b/templates/etc/ansible/facts.d/proc.fact.j2
@@ -22,7 +22,9 @@ if grep -qs '/proc' /proc/mounts ; then
     hidepid_gid="$(grep -E '^proc' /proc/mounts | awk '{print $4}' | awk -F',' '{for (i=1;i<=NF;i++) {if ($i ~ /gid=/) {print $i}}}' | cut -d= -f2)"
 
     # Find the hidepid group
-    hidepid_group="$(getent group ${hidepid_gid} | cut -d: -f1)"
+    if [ -n "${hidepid_gid}" ]; then
+        hidepid_group="$(getent group ${hidepid_gid} | cut -d: -f1)"
+    fi
 
 fi
 


### PR DESCRIPTION
If hidepid_group is empty then "getent group <hidepid_group>"
matches all. Accordingly hidepid_group mutates in a string matching the full
set of locally available groups.
This issue arise when a host has:
  console_proc_hidepid: False