### PR TITLE
Include the currently used CM engine in the /etc/issue file

### DIFF
--- a/templates/etc/issue.j2
+++ b/templates/etc/issue.j2
@@ -1,7 +1,7 @@
 
   [1;37m    /\\[0m       [1;36m\n.\O[0m
   [1;37m   /  \\[0m      [0;33m{{ console_issue }}[0m
-  [1;31m  Deb[1;36mOps[0m
+  [1;31m  Deb[1;36mOps[0m     [0;34mCM engine: Ansible[0m
   [1;37m   \\  /[0m      [1;33m\l [1;30m/ [1;32m\U[0m
   [1;37m    \\/[0m       [1;35m\s \r[0m
 


### PR DESCRIPTION
Line matches up with the "DebOps" line from the logo to indicate some
sort of connection.

![screenshot from 2016-08-02 09 39 43](https://cloud.githubusercontent.com/assets/1301158/17320897/241b43ce-5896-11e6-97cf-72e93f8c6d57.png)