### PR TITLE
Allow to disable shown user count from /etc/issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 # Custom string added to /etc/issue
 console_issue: '{{ ansible_domain.split(".")[0] | capitalize }}'
 
+# If ``True``, show the logged in users. Note that this count does only update
+# when the screen is manually refreshed.
+console__issue_show_logged_in_users: True
+
 # Enable or disable serial console (allows you to use 'lxc-console',
 # 'virsh console' and other similar commands)
 console_serial: False

--- a/templates/etc/issue.j2
+++ b/templates/etc/issue.j2
@@ -2,6 +2,6 @@
   [1;37m    /\\[0m       [1;36m\n.\O[0m
   [1;37m   /  \\[0m      [0;33m{{ console_issue }}[0m
   [1;31m  Deb[1;36mOps[0m
-  [1;37m   \\  /[0m      [1;33m\l [1;30m/ [1;32m\U[0m
+  [1;37m   \\  /[0m      [1;33m\l{% if (console__issue_show_logged_in_users|bool) %} [1;30m/ [1;32m\U{% endif %}[0m
   [1;37m    \\/[0m       [1;35m\s \r[0m
 


### PR DESCRIPTION
Reasons for which you might want to disable it:

* Imaginable to track admin login times in case of a hosted system.
  In case that network traffic is obfuscated. Note that this information
  can also gathered (arguably easier) with host memory access (without
  means for the guest to detect that).
* Count is only updated on manual refresh