### PR TITLE
Add per group/host variant of console_hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,6 +99,8 @@ console_proc_hidepid_group: 'procadmins'
 
 # Add or remove entries in /etc/hosts
 console_hosts: {}
+console_group_hosts: {}
+console_host_hosts: {}
 
 # Examples:
 # console_hosts:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -136,7 +136,7 @@
     regexp: '^{{ item.key | replace(".","\.") }}\s+'
     line: "{{ item.key }}\t{{ item.value if (item.value is string) else (item.value | join(' ')) }}"
     state: '{{ "present" if item.value|d() else "absent" }}'
-  with_dict: '{{ console_hosts }}'
+  with_dict: '{{ console_hosts|combine(console_group_hosts)|combine(console_host_hosts) }}'
   when: console_hosts|d()
   tags: [ 'role::console:hosts' ]
 


### PR DESCRIPTION
It is useful in environments where you have to access some hosts using different IPs but the same name.