### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ Removed
 - Remove support for ``root`` system account management. This functionality has
   been moved to a separate debops.root_account_ Ansible role. [drybjed_]
 
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 `debops.console v0.1.3`_ - 2016-11-07
 -------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,8 @@ Removed
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.console v0.1.3`_ - 2016-11-07

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,7 @@ Removed
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.console v0.1.3`_ - 2016-11-07

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   description: 'Configure system console and terminal-related options'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '1.7.0'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
   command: update-alternatives --list editor
   register: console_register_installed_editors
   changed_when: False
-  always_run: yes
+  check_mode: no
   tags: [ 'role::console:editor' ]
 
 - name: Configure system-wide editor

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -94,7 +94,7 @@
   command: update-alternatives --list editor
   register: console_register_installed_editors
   changed_when: False
-  check_mode: no
+  check_mode: False
   tags: [ 'role::console:editor' ]
 
 - name: Configure system-wide editor


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.